### PR TITLE
fix(package.json): updated prettier --write to prettier --check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,8 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG]: Short Title"
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-template.md
@@ -3,8 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[FEAT]: Short title"
 labels: enhancement
-assignees: ''
-
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
 ### Describe your changes
+
 Write here...
 
 ### Issue ticket number and link
+
 Write here...
 
 ### Please confirm the below message,
+
 - [ ] I confirm that I have performed a self-review of my code, and written explainable comments in the code, the UI is rendered without any errors, the UI is responsive, dark mode UI is implemented, removed all debug-related code.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "lint-staged": {
     "*.{css,less,scss,html,json,jsx,js}": [
-      "prettier --write ."
+      "prettier --check ."
     ],
     "*.js": "eslint --fix"
   },


### PR DESCRIPTION
Due to this change, while commiting a change, commitlint will only check for any non formated file.

### Describe your changes
Updated `lint-staged` option from `prettier --write` to `prettier --check`. Now commitlint will only check for any non format file, will not format automatically. The developer has to manually check for the files warned by commitlint and format them.
 
### Issue ticket number and link
NA

### Please confirm the below message,
- [X] I confirm that I have performed a self-review of my code, and written explainable comments in the code, the UI is rendered without any errors, the UI is responsive, dark mode UI is implemented, removed all debug-related code.
